### PR TITLE
Scope duplicate URL detection to ENV['CHANNEL_ID']

### DIFF
--- a/tars.rb
+++ b/tars.rb
@@ -31,7 +31,7 @@ channel_id = ENV['CHANNEL_ID']
 
 client.on(:message) do |data|
   p data
-  if data['type'] == 'message'
+  if data['type'] == 'message' && data['channel'] == channel_id
     urls = data['text'].to_s.scan(%r{https?://[^\s]+})
 
     if urls.any? { |url| url_exists? url }


### PR DESCRIPTION
This should stop TARS from complaining about reposts when people cross post a link  and also when @jamesottaway decides he wants to trigger it by sending a PM.
